### PR TITLE
Df co owner

### DIFF
--- a/docs/usage/df.md
+++ b/docs/usage/df.md
@@ -55,18 +55,19 @@ Here is a description of each column's output:
 |          | Column Name        | Example Value                         |
 |----------|--------------------|---------------------------------------|
 | *1*      | Path               | /data/CCBR/rawdata/ccbr123/           |
-| *2*      | Owner              | Guido van Rossum                      |
-| *3*      | Duplicated         | 177.316 GiB                           |
-| *4*      | Duplicated_Bytes   | 190391226983                          |
-| *5*      | Used               | 1.456 TiB                             |
-| ***6***  | ***%Duplicated***  | 0.0%                                  |
-| *7*      | wAgeS              | 12.4                                  |
-| *8*      | wDupS              | 0.0                                   |
-| *9*      | wOccS              | 5.1                                   |
-| ***10*** | ***Score***        | 82.5                                  |
+| *2*      | FolderOwner        | Guido van Rossum                      |
+| *3*      | FileCoOwners       | finneyr[96.297%]\|maggiec[3.703%]     |
+| *4*      | Duplicated         | 177.316 GiB                           |
+| *5*      | Duplicated_Bytes   | 190391226983                          |
+| *6*      | Used               | 1.456 TiB                             |
+| ***7***  | ***%Duplicated***  | 0.0%                                  |
+| *8*      | wAgeS              | 12.4                                  |
+| *9*      | wDupS              | 0.0                                   |
+| *10*     | wOccS              | 5.1                                   |
+| ***11*** | ***Score***        | 82.5                                  |
 
 
-***Please note:*** The output is seperated or delimited by tabs: `\t`. *%Duplciated* is reported as the `DuplicatedBytes/TotalBytes`. A *Score* is also assigned to a given path where the higher the score, the better. A *Score* of 0 would indicate that all the files are older than 2.7 years AND all the files are duplicates AND the files make up more than 10% of our shared group area. *wAgeS*, *wDupS*, and *wOccS* are the weighted indiviudal components that make up the *Score* listed in column 10.
+***Please note:*** The output is seperated or delimited by tabs: `\t`. *%Duplciated* is reported as the `DuplicatedBytes/TotalBytes`. A *Score* is also assigned to a given path where the higher the score, the better. A *Score* of 0 would indicate that all the files are older than 2.7 years AND all the files are duplicates AND the files make up more than 10% of our shared group area. *wAgeS*, *wDupS*, and *wOccS* are the weighted indiviudal components that make up the *Score* listed in column 11.
 
 ## Example
 

--- a/spacesaver
+++ b/spacesaver
@@ -58,7 +58,7 @@ def df(sub_args):
         Parsed arguments for run sub-command
     """
     # Column names of file listing
-    header = ['Path', 'Owner', 'Duplicated', 'Duplicated_Bytes', 'Used', '%Duplicated', 'wAgeS', 'wDupS', 'wOccS', 'Score']
+    header = ['Path', 'FolderOwner', 'FileCoOwners', 'Duplicated', 'Duplicated_Bytes', 'Used', '%Duplicated', 'wAgeS', 'wDupS', 'wOccS', 'Score']
     print('\t'.join(header))
 
     # Check for standard input 

--- a/src/commands.py
+++ b/src/commands.py
@@ -454,7 +454,7 @@ def _df(handler, path, split=False, quota=200):
             frac = fused / float(available)
         except ZeroDivisionError:
             frac = 0
-        fowner_str_list.append("{1}[{2}%]".format(fowner,round(frac * 100, 3)))
+        fowner_str_list.append("{0}[{1}%]".format(fowner,round(frac * 100, 3)))
 
     # create string for pipe separated file owners in the folder
     fowner_str = "|".join(fowner_str_list)

--- a/src/commands.py
+++ b/src/commands.py
@@ -412,6 +412,8 @@ def _df(handler, path, split=False, quota=200):
     
     # Owner of the provided path
     owner = _name(os.stat(path).st_uid, 'user')
+    available_per_user = dict()
+    available_per_user[owner] = 0
 
     for file_listing in handler:
         # Contents of file listing
@@ -429,6 +431,10 @@ def _df(handler, path, split=False, quota=200):
         ncopies  = int(file_listing[8])         # number of redundant copies
         duplicated += filesize * ncopies        # duplication size of files
         available += filesize * (ncopies + 1)   # total size of files
+        fowner = file_listing[2]                # file owner
+        if not fowner in available_per_user:
+            available_per_user[fowner] = 0
+        available_per_user[fowner] += available
 
         mtime = datetime.datetime.strptime(file_listing[6], '%Y-%m-%d-%H:%M')
         age = datetime.datetime.today() - mtime
@@ -438,6 +444,16 @@ def _df(handler, path, split=False, quota=200):
         except ZeroDivisionError:
             # File size is 0 bytes, add contribution of scaled age
             age_scores.append(scored(age) / age)
+        
+    # sort list by poweruser
+    available_per_user = dict(sorted(available_per_user.items(), key=lambda item: item[1], reverse=True))
+    
+    fowner_str_list = []
+    for fowner,fused in available_per_user.items():
+        fowner_str_list.append("{}%".format(round(fused / float(available) * 100, 3)))
+
+    # create string for pipe separated file owners in the folder
+    fowner_str = "|".join(fowner_str_list)
 
     # Age Score is the average age score of all files,
     # where age is scaled via the scored() function.
@@ -477,7 +493,7 @@ def _df(handler, path, split=False, quota=200):
     DupC = str(round(100 * (wDup*DupScore), 1))
     OccC = str(round(100 * (wOcc*OccScore), 1))
 
-    return [path, owner, readable_size(duplicated), str(duplicated), readable_size(available), percent_duplicates, AgeC, DupC, OccC, Score]
+    return [path, owner, fowner_str, readable_size(duplicated), str(duplicated), readable_size(available), percent_duplicates, AgeC, DupC, OccC, Score]
 
 
 def _ln(path, minimum_size=10485760):

--- a/src/commands.py
+++ b/src/commands.py
@@ -454,7 +454,7 @@ def _df(handler, path, split=False, quota=200):
             frac = fused / float(available)
         except ZeroDivisionError:
             frac = 0
-        fowner_str_list.append("{0}[{1}%]".format(fowner,round(frac * 100, 3)))
+        fowner_str_list.append("{0}[{1}%]".format(fowner,round(frac * 100, 1)))
 
     # create string for pipe separated file owners in the folder
     fowner_str = "|".join(fowner_str_list)


### PR DESCRIPTION
Sometimes the folder is owned by one user and the files inside the folder are owned by another. In such cases, it is important whom to reach out to for removing/reducing duplication. Hence adding 2 new columns (`FolderOwner`and `FileCoOwners`) in place of the `owner` column. Eg.
```bash
Path	FolderOwner	FileCoOwners	Duplicated	Duplicated_Bytes	Used	%Duplicated	wAgeS	wDupS	wOccS	Score
/data/CCBR/projects/ccbr984	kopardevn	finneyr[96.297%]|maggiec[3.703%]|kopardevn[0.0%]	898.971 GiB	965263273292	9.622 TiB	9.124%	8.7	4.1	33.7	53.5
```