### PR TITLE
Biowulf cronjob

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,9 @@ dmypy.json
 
 # Ignore logfiles 
 logs/
+log_*/
+**/.koparde*
+**/slurm-*
 
 # Ignore swarm files
 *.e

--- a/utils/cronjob.sh
+++ b/utils/cronjob.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+set -exo pipefail
+export PATH=$PATH:/usr/local/bin
+export PATH=$PATH:/usr/local/slurm/bin
+echo $PATH
+
+dt=$(date "+%m%d%y")
+#dt="061322"
+spacesaver_dir="/data/CCBR/dev/spacesavers"
+spacesaver_exe="${spacesaver_dir}/spacesaver"
+outdir="${spacesaver_dir}/log_${dt}"
+# copy report to $report
+# $report will be attached to the email sent out by a cronjob on helix
+# FYI, email cronjob only works out of helix (not biowulf)
+report="${spacesaver_dir}/log/duplication_report.html"
+if [ -d $outdir ];then
+	rm -rf $outdir
+fi
+mkdir -p $outdir 
+cd $outdir
+
+do_ls=1
+do_df=1
+do_report=1
+do_cleanup=1
+
+if [ "$do_ls" == "1" ];then
+# do ls
+for f in $(find /data/CCBR/projects -maxdepth 1 -type d);do 
+	g=$(echo $f|awk -F"/" '{print $NF}');
+	echo "${spacesaver_exe} ls $f 1>${outdir}/${g}_projects_ls.tsv 2>${outdir}/${g}_projects_ls.err";
+done > do_ls_swarm
+for f in $(find /data/CCBR/rawdata -maxdepth 1 -type d);do 
+	g=$(echo $f|awk -F"/" '{print $NF}');
+	echo "${spacesaver_exe} ls $f 1>${outdir}/${g}_rawdata_ls.tsv 2>${outdir}/${g}_rawdata_ls.err";
+done >> do_ls_swarm
+swarm -f do_ls_swarm -t 2 -g 200 --partition=ccr,norm --time=24:00:00 --sbatch "--wait"
+fi
+
+if [ "$do_df" == "1" ];then
+# do df
+# eg.
+# ./cat ccbr123_ls.tsv | spacesaver df /data/CCBR/rawdata/ccbr123/
+for f in $(find /data/CCBR/rawdata -maxdepth 1 -type d);do
+	g=$(echo $f|awk -F"/" '{print $NF}')
+	if [ "$g" != "rawdata" ];then
+		echo "cat ${outdir}/${g}_rawdata_ls.tsv | ${spacesaver_exe} df $f 1> ${outdir}/${g}_rawdata_df.tsv 2> ${outdir}/${g}_rawdata_df.err"
+	fi
+done > do_df_swarm
+for f in $(find /data/CCBR/projects -maxdepth 1 -type d);do
+	g=$(echo $f|awk -F"/" '{print $NF}')
+	if [ "$g" != "projects" ];then
+		echo "cat ${outdir}/${g}_projects_ls.tsv | ${spacesaver_exe} df $f 1> ${outdir}/${g}_projects_df.tsv 2> ${outdir}/${g}_projects_df.err"
+	fi
+done >> do_df_swarm
+# these are fast .. no need to swarm
+bash do_df_swarm
+fi
+
+if [ "$do_report" == "1" ];then
+	cat > ${outdir}/render_report.R << EOF
+rmarkdown::render("${spacesaver_dir}/utils/make_ccbr_duplicate_report.Rmd", 
+output_file = "${outdir}/duplication_report.html",
+encoding = "UTF-8",
+params = list(directory = "${outdir}"))
+EOF
+	cat > ${outdir}/do_report << EOF
+#!/bin/bash
+#SBATCH --job-name="spacesavers report"
+#SBATCH --mem=40g
+#SBATCH --partition="ccr,norm"
+#SBATCH --time=12:00:00
+#SBATCH --cpus-per-task=2
+module load R
+Rscript ${outdir}/render_report.R
+if [ -f "${outdir}/duplication_report.html" ];then
+cp ${outdir}/duplication_report.html $report
+fi
+chmod -R a+rX $report
+EOF
+sbatch --wait ${outdir}/do_report
+fi
+
+if [ "$do_cleanup" == "1" ];then
+cd $outdir
+rm -rf *_ls.tsv
+rm -rf *_ls.err
+rm -rf *_df.tsv
+rm -rf *_df.err
+rm -rf all_lss.tsv all_dfs.tsv
+rm -rf swarm*
+fi
+

--- a/utils/cronjob_submit.sh
+++ b/utils/cronjob_submit.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#SBATCH --job-name="spacesavers"
+#SBATCH --mem=10g
+#SBATCH --partition="ccr,norm"
+#SBATCH --time=96:00:00
+#SBATCH --cpus-per-task=2
+source $HOME/.bashrc
+bash /data/CCBR/dev/spacesavers/utils/cronjob.sh

--- a/utils/make_ccbr_duplicate_report.Rmd
+++ b/utils/make_ccbr_duplicate_report.Rmd
@@ -1,0 +1,186 @@
+---
+title: "CCBR data mount duplication report"
+date: "`r format(Sys.time(), '%d %B, %Y')`"
+output: html_document
+params:
+  directory: "/home/kopardevn/CCBR/dev/spacesavers/logs"
+  dups_file: "large_duplicated.tsv"
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+library(ggplot2)
+library(dplyr)
+library(DT)
+```
+
+```{r copy_params_to_bash_env, echo=FALSE, message=FALSE}
+
+# this block will copy all params variable into bash env variable
+# which will be accessible in the bash block
+# eg. params$directory will be accessible as $directory in bash block
+
+for (key in names(params)) {
+  do.call('Sys.setenv', params[key])
+}
+large_dup_file_path = file.path(params$directory,params$dups_file)
+Sys.setenv(DUPFILE = large_dup_file_path)
+```
+
+```{bash echo=FALSE}
+n=1
+for f in `ls ${directory}/*_ls.tsv`
+do
+if [[ "$n" == "1" ]]
+then
+head -n1 $f
+fi
+n=$((n+1))
+tail -n +2 $f
+done | awk -F"\t" '{if (NF==13) {print}}' > ${directory}/all_lss.tsv
+```
+
+
+```{bash echo=FALSE}
+n=1
+for f in `ls ${directory}/*_df.tsv`
+do
+if [[ "$n" == "1" ]]
+then
+head -n1 $f
+fi
+n=$((n+1))
+tail -n +2 $f
+done | awk -F"\t" '{if (NF==11) {print}}' > ${directory}/all_df.tsv
+```
+
+```{r load_ls,include=TRUE,echo=FALSE}
+ls_filepath=file.path(params$directory,"all_lss.tsv")
+df = read.csv(ls_filepath,
+                header = TRUE,
+                check.names = FALSE,
+                sep = "\t",
+                comment.char = "#")
+df = df[df$Bytes != 0,]
+df = df[!is.na(df$Bytes),]
+df = df[!is.na(df$BDuplicates),]
+
+# select 100MB or larger duplicates and write them out
+large_dup_df = df[df$BDuplicates>100*1024*1024,]
+write.table(large_dup_df,
+            file = large_dup_file_path,
+            quote = FALSE,
+            row.names = FALSE,
+            sep="\t")
+
+```
+
+```{r load_df,include=TRUE,echo=FALSE}
+df_filepath=file.path(params$directory,"all_df.tsv")
+df_df = read.csv(df_filepath,
+                header = TRUE,
+                check.names = FALSE,
+                sep = "\t",
+                comment.char = "#")
+
+df_df = df_df[!is.na(df_df$Duplicated_Bytes),]
+df_df = df_df[!is.na(df_df$Score),]
+df_df = df_df[df_df$Duplicated_Bytes > 100*1024*1024,]
+df_df$DupGiB = df_df$Duplicated_Bytes/1024/1024/1024
+df_df = df_df[order(df_df$DupGiB,decreasing=TRUE),]
+rownames(df_df) = NULL
+
+```
+
+## Background
+
+[Spacesavers](https://github.com/CCBR/spacesavers) is used to assess the duplications levels in the `/data/CCBR/projects` and `/data/CCBR/rawdata` subfolders individually. A swarm job runs `spacesaver ls` command for each these subfolders thereby generating a [TSV file](https://ccbr.github.io/spacesavers/usage/ls/#output) for each subfolder. These results are then:
+
+- concatenated across all subfolders
+- filtered for duplicates-only
+- filtered for duplication of 100 MiB or greater, i.e., ignore smaller duplicates as they do not make a big impact towards overall diskspace
+
+> **NOTE**: Ideally, we would prefer to run `spacesavers` on the entire `/data/CCBR` mount, but this is not possible as it will take long time to run (days or weeks). `spacesavers` does optimize calculation of md5sum of larger files but the md5sum calculations are NOT performed in parallel. Hence, we _pseudo_-parallelize the process by running multiple instances of `spacesavers` as a swarm job. **Disclaimer**: Inter-project duplicates will be missed by our swarm job.
+
+## Size Per User
+
+```{r sizeperuser, include=TRUE, echo=FALSE}
+df %>% group_by(Owner) %>% summarise(Bytes = sum(Bytes)) %>% as.data.frame -> df_bytes_per_user
+df_bytes_per_user$GiB = df_bytes_per_user$Bytes/1024/1024/1024
+ggplot(df_bytes_per_user,aes(x=reorder(Owner, GiB),y=GiB)) + 
+  geom_bar(stat = 'identity',aes(fill=Owner)) + 
+  coord_flip() + 
+  theme_bw() + 
+  theme(legend.position = "none") + 
+  ylab("TotalSize(GiB)") + 
+  xlab("User")
+```
+
+
+## Duplication Size
+
+```{r dupsize, include=TRUE, echo=FALSE}
+df %>% group_by(Owner) %>% summarise(BDuplicates = sum(BDuplicates)) %>% as.data.frame -> df_dup_bytes_per_user
+df_dup_bytes_per_user$GiB = df_dup_bytes_per_user$BDuplicates/1024/1024/1024
+ggplot(df_dup_bytes_per_user,aes(x=reorder(Owner, GiB),y=GiB)) + 
+  geom_bar(stat = 'identity',aes(fill=Owner)) + 
+  coord_flip() + 
+  theme_bw() + 
+  theme(legend.position = "none") + 
+  ylab("DuplicationSize(GiB)") + 
+  xlab("User")
+```
+
+## Top 20 most duplicated folders
+
+```{r mostdup, include=TRUE, echo=FALSE}
+ggplot(head(df_df,20),aes(x=reorder(Path,DupGiB),y=DupGiB)) + 
+  geom_bar(stat = 'identity',aes(fill=Path)) + 
+  coord_flip() + 
+  theme_bw() + 
+  theme(legend.position = "none") + 
+  ylab("Duplication(GiB)") + 
+  xlab("Folder")
+```
+
+## Per folder duplication levels
+
+```{r duptable,echo=FALSE,include=TRUE}
+DT::datatable(df_df,
+              class = 'cell-border stripe',
+              rownames = FALSE)
+```
+
+## Score distribution
+
+```{r score,include=TRUE,echo=FALSE}
+ggplot(df_df,aes(x=Score)) + 
+  geom_density() +
+  theme_bw() + 
+  theme(legend.position = "none") + 
+  ylab("Density") + 
+  xlab("Score")
+
+```
+
+## Top 20 lowest score folders
+
+```{r lowestscore, include=TRUE, echo=FALSE}
+df_df = df_df[order(df_df$Score),]
+path_level = df_df$Path
+ggplot(head(df_df,20),aes(x=factor(Path,level=rev(path_level)),y=Score)) + 
+  geom_bar(stat = 'identity',aes(fill=Path)) + 
+  coord_flip() + 
+  theme_bw() + 
+  theme(legend.position = "none") + 
+  ylab("Duplication(GiB)") + 
+  xlab("Folder")
+```
+
+## Your duplicates
+
+If you wish to see a list of your duplicate files, please run this on helix:
+```{bash echo=FALSE,include=TRUE}
+echo "bash /data/CCBR/dev/spacesavers/logs/show_my_dups.sh $DUPFILE | less"
+```
+

--- a/utils/run_cronjob_submit.sh
+++ b/utils/run_cronjob_submit.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# this script should be called from crontab to submit the cronjob.sh
+# script to the slurm queue
+source $HOME/.bashrc
+sbatch /data/CCBR/dev/spacesavers/utils/cronjob_submit.sh

--- a/utils/send_email.py
+++ b/utils/send_email.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+from __future__ import print_function, division
+from os.path import basename
+from email.mime.application import MIMEApplication
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+import datetime, sys, smtplib, subprocess
+
+EMAILLIST=["maggiec","fitzgepe","jailwalapa","finneyr","zhaoyong","nelsong","lobanovav","kopardevn","abdelmaksoudaa","meyertj","wongnw","stonelakeak","sevillas2","homanpj","pehrssonec","nousomedr","bianjh"]
+EMAILLIST = list(map(lambda x:x+"@nih.gov",EMAILLIST))
+
+def _get_ccbr_email_list():
+    """
+    Use unix commands to get the list of usernames/emails for all group members of CCBR group on biowulf
+    """
+    cmd = "grep ^CCBR: /etc/group | awk -F\":\" '{print $NF}'"
+    proc = subprocess.run(cmd,shell=True,capture_output=True,text=True)
+    if str(exitcode) == "0":
+        userlist = proc.stdout
+        userlist = userlist.strip().split(",")
+        userlist = list(map(lambda x:x+"@nih.gov",userlist))
+        return userlist
+    else:
+        return EMAILLIST
+
+def send_email(email_subject, email_text, attachment, from_sender="kopardevn@nih.gov", to_receiver="kopardevn@nih.gov"):
+    """
+    Sends email from sender to receiver attaches email text and html to body
+    :param from_sender: <str>
+    :param to_receiver: <str>
+    :param email_subject: <str>
+    :param email_text: <str>
+    :param email_html: <str>
+    :return:
+    """
+
+    # Create message container - the correct MIME type is multipart/alternative.
+    msg = MIMEMultipart('alternative')
+    msg['Subject'] = email_subject
+    msg['From'] = from_sender
+    msg['To'] = ", ".join(to_receiver)
+
+    # Record the MIME types of both parts - text/plain and text/html.
+    part1 = MIMEText(email_text, 'plain')
+    msg.attach(part1)
+    with open(attachment, "rb") as fil:
+        part2 = MIMEApplication(fil.read(),Name=basename(attachment))
+
+    # After the file is closed
+    part2['Content-Disposition'] = 'attachment; filename="%s"' % basename(attachment)
+    msg.attach(part2)
+
+    # Send the message via local SMTP server.
+    s = smtplib.SMTP('localhost')
+    # sendmail function takes 3 arguments: sender's address, recipient's address
+    # and message to send - here it is sent as one string.
+    s.sendmail(from_sender, to_receiver, msg.as_string())
+    s.quit()
+
+    return
+
+def main():
+    attachment=sys.argv[1]
+    email_subject = "CCBR mount weekly disk utilization report!"
+    email_text = "Good Morning!\n"
+    email_text += "You are receiving this email because you are a member of the \"CCBR\" group on Biowulf. The attached report illustrates:\n"
+    email_text += " a. per-user disk utilization\n"
+    email_text += " b. per-user duplication\n"
+    email_text += " c. list of folders with most duplication\n"
+    email_text += " d. searchable details per folder\n"
+    email_text += " e. spacesavers score distribution and\n"
+    email_text += "other important metrics and visuals."
+    email_text += "Please use this report to prioritize your de-duplication efforts and regularly track the 200TB CCBR data mount storage utilization. You will receive an updated report every week.\n"
+    email_text += "Have a good day!\n"
+    email_text += "Vishal Koparde, Ph.D., CCBR\n"
+    #test
+    #send_email(email_subject=email_subject,email_text=email_text,attachment=attachment,to_receiver=['kopardevn@nih.gov','vishal.koparde@gmail.com'])
+    #prod
+    send_email(email_subject=email_subject,email_text=email_text,attachment=attachment,to_receiver=_get_ccbr_email_list())
+
+
+if __name__ == '__main__':
+    main()

--- a/utils/show_my_dups.sh
+++ b/utils/show_my_dups.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+me=$(readlink -f $0)
+
+if [[ "$#" != "1" ]];then
+	cat << EOF
+	Usage:
+	This script outputs your duplicate files found using spacesavers
+	sorted by descending size.
+	eg.
+	%> bash $me <aggregated df file>
+EOF
+exit
+fi
+
+large_dups_file=$1
+
+head -n1 $large_dups_file
+
+awk -F"\t" -v u=$USER -v OFS="\t" '{if ($3==u) {print}}' $large_dups_file | sort -k10,10nr


### PR DESCRIPTION
Adding scripts to create a weekly reporting cronjob.

  - `run_cronjob_submit.sh`: script that submits the cronjob, i.e., script to be added to `crontab`
  - `cronjob_submit.sh`: script to submit a slurm job for running a series of taskings (including spacesavers subcommands) 
  - `cronjob.sh`: actual list of commands that sequentially run:
    - `spacesaver ls` to gather detailed report
    - `spacesaver df` to summarize on a per-folder level
    - create report using `make_ccbr_duplicate_report.Rmd` script
    - cleanup ,i.e., delete intermediate files and save space
  - `show_my_dups.sh`: which filters duplicate for each user and sorts by descending size to help prioritize deduplication
  - `send_email.py`: script to send email notification via a separate cronjob running on helix.